### PR TITLE
Remove references to the on-prem Matomo instance

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -48,9 +48,6 @@
     var u="https://cessda.matomo.cloud/";
     _paq.push(['setTrackerUrl', u+'matomo.php']);
     _paq.push(['setSiteId', '{{ site.matomo_siteid }}']);
-    var secondaryTrackerUrl = 'https://analytics.cessda.eu/matomo.php';
-    var secondaryWebsiteId = {{ site.matomo_siteid }};
-    _paq.push(['addTracker', secondaryTrackerUrl, secondaryWebsiteId]);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
     g.type='text/javascript'; g.async=true; g.src='//cdn.matomo.cloud/cessda.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
   })();


### PR DESCRIPTION
The Matomo instance at  https://analytics.cessda.eu/ has been shut down.

This closes #8